### PR TITLE
Engageurl and settings field type

### DIFF
--- a/filter.php
+++ b/filter.php
@@ -69,24 +69,28 @@ class filter_opencast extends moodle_text_filter {
                 } else if ($video) {
                     $video = false;
                     if (substr($match, 0, 7) === "<source") {
-                        // Get apiurl from opencast tool.
-                        $apiurl = get_config('tool_opencast', 'apiurl');
+                        // Get baseurl either from engageurl setting or from opencast tool.
+                        $baseurl = get_config('filter_opencast', 'engageurl');
+                        if (empty($baseurl)) {
+                            $baseurl = get_config('tool_opencast', 'apiurl');
+                        }
+
 
                         // Check if video is from opencast.
-                        if (strpos($match, $apiurl) === false) {
+                        if (strpos($match, $baseurl) === false) {
                             continue;
                         }
 
-                        if (strpos($apiurl, 'http') !== 0) {
-                            $apiurl = 'http://' . $apiurl;
+                        if (strpos($baseurl, 'http') !== 0) {
+                            $baseurl = 'http://' . $baseurl;
                         }
 
                         // Extract id.
                         $id = substr($match, strpos($match, 'api/') + 4, 36);
-                        $src = $CFG->wwwroot . '/filter/opencast/player/core.html?id=' . $id . '&ocurl=' . urlencode($apiurl);
+                        $src = $CFG->wwwroot . '/filter/opencast/player/core.html?id=' . $id . '&ocurl=' . urlencode($baseurl);
 
                         // Create link to video.
-                        $link = $apiurl . '/engage/theodul/ui/core.html?id=' . $id;
+                        $link = $baseurl . '/engage/theodul/ui/core.html?id=' . $id;
 
                         // Collect the needed data being submitted to the template.
                         $mustachedata = new stdClass();

--- a/lang/en/filter_opencast.php
+++ b/lang/en/filter_opencast.php
@@ -29,3 +29,5 @@ $string['setting_consumerkey'] = 'Consumer key';
 $string['setting_consumerkey_desc'] = 'LTI Consumer key';
 $string['setting_consumersecret'] = 'Consumer secret';
 $string['setting_consumersecret_desc'] = 'LTI Consumer secret';
+$string['setting_engageurl'] = 'URL of the Opencast Engange server';
+$string['setting_engageurl_desc'] = 'If empty, the base URL of the admin tool is used.';

--- a/settings.php
+++ b/settings.php
@@ -30,4 +30,8 @@ if ($ADMIN->fulltree) {
     $settings->add(new admin_setting_configpasswordunmask('filter_opencast/consumersecret',
         get_string('setting_consumersecret', 'filter_opencast'),
         get_string('setting_consumersecret_desc', 'filter_opencast'), ''));
+    $settings->add(new admin_setting_configtext('filter_opencast/engageurl',
+        get_string('setting_engageurl', 'filter_opencast'),
+        get_string('setting_engageurl_desc', 'filter_opencast'), ''));
+
 }

--- a/settings.php
+++ b/settings.php
@@ -27,7 +27,7 @@ if ($ADMIN->fulltree) {
     $settings->add(new admin_setting_configtext('filter_opencast/consumerkey',
         get_string('setting_consumerkey', 'filter_opencast'),
         get_string('setting_consumerkey_desc', 'filter_opencast'), ''));
-    $settings->add(new admin_setting_configtext('filter_opencast/consumersecret',
+    $settings->add(new admin_setting_configpasswordunmask('filter_opencast/consumersecret',
         get_string('setting_consumersecret', 'filter_opencast'),
         get_string('setting_consumersecret_desc', 'filter_opencast'), ''));
 }

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2018021501;        // The current plugin version (Date: YYYYMMDDXX).
+$plugin->version = 2018031900;        // The current plugin version (Date: YYYYMMDDXX).
 $plugin->requires = 2017050500;        // Requires this Moodle version.
 $plugin->component = 'filter_opencast'; // Full name of the plugin.
 $plugin->dependencies = array('tool_opencast' => ANY_VERSION);


### PR DESCRIPTION
I added the possibility to specify a second url to distinguish between External API and Engage Server.
Additionally, the password field is now masked.