### PR TITLE
fixed iframes loading before authentication

### DIFF
--- a/filter.php
+++ b/filter.php
@@ -61,11 +61,9 @@ class filter_opencast extends moodle_text_filter {
             $renderer = $PAGE->get_renderer('filter_opencast');
 
             // Login if user is not logged in yet.
-            $loggedin = true;
             if (!self::$loginrendered) {
                 // Login and set cookie.
                 filter_opencast_login();
-                $loggedin = false;
                 self::$loginrendered = true;
             }
 
@@ -99,7 +97,6 @@ class filter_opencast extends moodle_text_filter {
 
                         // Collect the needed data being submitted to the template.
                         $mustachedata = new stdClass();
-                        $mustachedata->loggedin = $loggedin;
                         $mustachedata->src = $src;
                         $mustachedata->link = $link;
 

--- a/templates/player.mustache
+++ b/templates/player.mustache
@@ -21,14 +21,11 @@
   The purpose of this template is to render a opencast video.
 }}
 
-{{! Print the iframe. }}
-{{# loggedin}}
-    <iframe src="{{src}}" width="95%" height="455px" class="ocplayer" allowfullscreen="true"></iframe>
-{{/ loggedin}}
-{{^loggedin}}
-{{! Don't load the video yet if not logged in. }}
-    <iframe data-frameSrc="{{src}}" width="95%" height="455px" class="ocplayer" allowfullscreen="true"></iframe>
-{{/loggedin}}
+{{!
+    Print the iframe.
+    Don't load the video yet, because we have to assume the user is not logged in yet.
+}}
+<iframe data-frameSrc="{{src}}" width="95%" height="455px" class="ocplayer" allowfullscreen="true"></iframe>
 {{! Print the link to the video. }}
 <a style="display:block;" target="_blank" href="{{link}}">Zum Video</a>
 


### PR DESCRIPTION
When more than one video was on a page every video except for the first
could be loaded before the authentication was even finished.

Fixes #22.