### PR TITLE
configurable width, height and autoplay

### DIFF
--- a/filter.php
+++ b/filter.php
@@ -75,6 +75,17 @@ class filter_opencast extends moodle_text_filter {
             	// Check if the match is a video tag.
                 if (substr($match, 0, 6) === "<video") {
                     $video = true;
+                    
+                    //get width and height
+                    $iswidth = preg_match('/width=\"(\d*.?.?)\"/', $match, $width);
+                    $isheight = preg_match('/height=\"(\d*.?.?)\"/', $match, $height);
+                    
+                    //get autoplay
+                    $autoplay = '';
+                    if(strpos($match, 'autoplay')){
+                    	$autoplay = '&autoplay=true';
+                    }
+                    
                 } else if ($video) {
                     $video = false;
                     if (substr($match, 0, 7) === "<source") {
@@ -95,13 +106,32 @@ class filter_opencast extends moodle_text_filter {
                         }
 
                         // Create source with embedded mode.
-                        $src = $link;
+                        $src = $link . $autoplay;
 
                         // Collect the needed data being submitted to the template.
                         $mustachedata = new stdClass();
                         $mustachedata->loggedin = $loggedin;
                         $mustachedata->src = $src;
                         $mustachedata->link = $link;
+                        $mustachedata->allowfullscreen = get_config('filter_opencast', 'allowfullscreen');
+                        
+                        $prewidth  = "width=";
+                        $preheight = "height=";
+                        
+                        //no custom width or height set in video-tag
+                        if(!$iswidth && !$isheight){
+                        	$mustachedata->width = $prewidth.get_config('filter_opencast', 'defaultwidth');
+                        	$mustachedata->height = $preheight.get_config('filter_opencast', 'defaultheight');
+                        } else {
+                        	
+                        	if (!empty($width[1])) {
+                        		$mustachedata->width = $prewidth.$width[1];
+                        	}
+                        	
+                        	if (!empty($height[1])) {
+                        		$mustachedata->height = $preheight.$height[1];
+                        	}
+                        }
 
                         $newtext =  $renderer->render_player($mustachedata);
 

--- a/lang/de/filter_opencast.php
+++ b/lang/de/filter_opencast.php
@@ -15,27 +15,27 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * Strings for component 'filter_opencastfilter', language 'en'
+ * Strings for component 'filter_opencastfilter', language 'de'
  *
  * @package   filter_opencastfilter
- * @copyright 2017 Tamara Gunkel
+ * @copyright 2019 Hanno Monschan
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
 defined('MOODLE_INTERNAL') || die();
 $string['filtername'] = 'Opencast';
 $string['pluginname'] = 'Opencast Filter';
-$string['setting_allowfullscreen'] = 'Allow fullscreen';
-$string['setting_allowfullscreen_desc'] = 'Allow fullscreen for Opencast player window';
+$string['setting_allowfullscreen'] = 'Vollbildmodus erlauben';
+$string['setting_allowfullscreen_desc'] = 'Vollbildmodus für das Opencast Player Fenster erlauben';
 $string['setting_consumerkey'] = 'Consumer key';
 $string['setting_consumerkey_desc'] = 'LTI Consumer key';
 $string['setting_consumersecret'] = 'Consumer secret';
 $string['setting_consumersecret_desc'] = 'LTI Consumer secret';
-$string['setting_defaultwidth'] = 'Default widht of the Opencast player window';
-$string['setting_defaultwidth_desc'] = 'Default width of the Opencast player window, e.g. 95% , 666, 666px';
-$string['setting_defaultheight'] = 'Default height of the Opencast player window';
-$string['setting_defaultheight_desc'] = 'Default height of the Opencast player window, e.g. 100%, 495, 495px';
-$string['setting_engageurl'] = 'URL of the Opencast Engage server';
-$string['setting_engageurl_desc'] = 'If empty, the base URL of the admin tool is used.';
-$string['setting_playerurl'] = 'URL of the Opencast player';
-$string['setting_playerurl_desc'] = 'Relative URL of the Opencast player, e.g. /engage/theodul/ui/core.html for the Theodul Pass Player or /paella/ui/watch.html for Paella Player.';
+$string['setting_defaultwidth'] = 'Pixel Standard-Fensterbreite des Opencast Players';
+$string['setting_defaultwidth_desc'] = 'Pixel Standard-Fensterbreite des Opencast Players, z.B. 95% , 666, 666px';
+$string['setting_defaultheight'] = 'Pixel Standard-Fensterhöhe des Opencast Players';
+$string['setting_defaultheight_desc'] = 'Pixel Standard-Fensterhöhe des Opencast Players, z.B. 100%, 495, 495px';
+$string['setting_engageurl'] = 'URL des Opencast Engage Servers';
+$string['setting_engageurl_desc'] = 'Falls nicht angegeben, wird die Basis URL der Admin-Instanz verwendet.';
+$string['setting_playerurl'] = 'URL des Opencast Players';
+$string['setting_playerurl_desc'] = 'Die relative URL des Opencast Players, z.B. /engage/theodul/ui/core.html für den Theodul Pass Player oder /paella/ui/watch.html für den Paella Player.';

--- a/settings.php
+++ b/settings.php
@@ -28,14 +28,31 @@ if ($ADMIN->fulltree) {
     $settings->add(new admin_setting_configtext('filter_opencast/consumerkey',
         get_string('setting_consumerkey', 'filter_opencast'),
         get_string('setting_consumerkey_desc', 'filter_opencast'), ''));
+    
     $settings->add(new admin_setting_configpasswordunmask('filter_opencast/consumersecret',
         get_string('setting_consumersecret', 'filter_opencast'),
         get_string('setting_consumersecret_desc', 'filter_opencast'), ''));
+    
     // Opencast settings.
     $settings->add(new admin_setting_configtext('filter_opencast/engageurl',
         get_string('setting_engageurl', 'filter_opencast'),
         get_string('setting_engageurl_desc', 'filter_opencast'), ''));
+    
     $settings->add(new admin_setting_configtext('filter_opencast/playerurl',
         get_string('setting_playerurl', 'filter_opencast'),
         get_string('setting_playerurl_desc', 'filter_opencast'), ''));
+    
+    $options = array('' => get_string('no'), 'allowfullscreen' => get_string('yes'));
+    $settings->add(new admin_setting_configselect('filter_opencast/allowfullscreen',
+    	get_string('setting_allowfullscreen', 'filter_opencast'),
+    	get_string('setting_allowfullscreen_desc', 'filter_opencast'),
+    	'allowfullscreen', $options));
+    
+    $settings->add(new admin_setting_configtext('filter_opencast/defaultwidth',
+    	get_string('setting_defaultwidth', 'filter_opencast'),
+    	get_string('setting_defaultwidth_desc', 'filter_opencast'), '95%'));
+    
+    $settings->add(new admin_setting_configtext('filter_opencast/defaultheight',
+    	get_string('setting_defaultheight', 'filter_opencast'),
+    	get_string('setting_defaultheight_desc', 'filter_opencast'), '455px'));
 }

--- a/templates/player.mustache
+++ b/templates/player.mustache
@@ -23,12 +23,11 @@
 
 {{! Print the iframe. }}
 {{# loggedin}}
-    <iframe src="{{src}}" width="95%" height="455px" class="ocplayer" allowfullscreen="true"></iframe>
+    <iframe src="{{src}}" {{width}} {{height}} class="ocplayer" {{allowfullscreen}}></iframe>
 {{/ loggedin}}
 {{^loggedin}}
 {{! Don't load the video yet if not logged in. }}
-    <iframe data-frameSrc="{{src}}" width="95%" height="455px" class="ocplayer" allowfullscreen="true"></iframe>
+    <iframe data-frameSrc="{{src}}" {{width}} {{height}} class="ocplayer" {{allowfullscreen}}></iframe>
 {{/loggedin}}
 {{! Print the link to the video. }}
 <a style="display:block;" target="_blank" href="{{link}}">Zum Video</a>
-


### PR DESCRIPTION
Defaults for width, height and autoplay globally configurable by Moodle-admin.
Applies user set width and height to iframe, tested with Paella player.
(Atto->media->video->Display otions)