### PR TITLE
Make filter work properly with linebreaks

### DIFF
--- a/filter.php
+++ b/filter.php
@@ -81,6 +81,9 @@ class filter_opencast extends moodle_text_filter {
                     $height = false;
 
                     foreach ($matches as $match) {
+                        if (empty(trim($match))) {
+                            continue;
+                        }
                         // Check if the match is a video tag.
                         if (substr($match, 0, 6) === "<video") {
                             $video = true;
@@ -163,7 +166,7 @@ class filter_opencast extends moodle_text_filter {
                                 }
 
                                 // Replace video tag.
-                                $text = preg_replace('/<video(?:(?!<\/video>).)*?' . preg_quote($match, '/') . '.*?<\/video>/',
+                                $text = preg_replace('/<video(?:(?!<\/video>).)*?' . preg_quote($match, '/') . '.*?<\/video>/s',
                                     $newtext, $text, 1);
                             }
                             $width = $height = false;


### PR DESCRIPTION
This fixes #42.

A string like `'<video>\r\n        <source src="...">'` will be split into `['<video>', '\r\n      ', '<source src="...">']` by L. 76.
This pr makes sure that `$video` will not be set to `false` by the whitespace between the two tags. Also, `.` in a regex matches everything *except newlines* by default. The `/s` flag [causes newlines to matched by the dot as well](https://www.php.net/manual/en/reference.pcre.pattern.modifiers.php). 

This makes embeds with the new default moodle editor work. But I will probably rewrite the filtering logic soon, since the current code parses the complete text for each episodeurl for each opencast instance, which is unnecessary. Then I could also make the url finding much more robust and also accept `<video src="...">`, as was put up for discussion in #35.