### PR TITLE
Fixes Opencast-Moodle/moodle-filter_opencast#54 (#55)

### DIFF
--- a/classes/text_filter.php
+++ b/classes/text_filter.php
@@ -212,7 +212,7 @@ class text_filter extends \core_filters\text_filter {
             int $playerid, $width = null, $height = null) {
         global $OUTPUT, $PAGE, $COURSE;
 
-        $data = paella_transform::get_paella_data_json($ocinstanceid, $episodeid);
+        list($data, $errormessage) = paella_transform::get_paella_data_json($ocinstanceid, $episodeid);
 
         if (!$data) {
             return null;
@@ -253,9 +253,10 @@ class text_filter extends \core_filters\text_filter {
             $renderer = $PAGE->get_renderer('filter_opencast');
             return $renderer->render_player($mustachedata);
         } else {
+            $notificationmessage = !empty($errormessage) ? $errormessage : get_string('erroremptystreamsources', 'mod_opencast');
             return $OUTPUT->render(new \core\output\notification(
-                    get_string('erroremptystreamsources', 'mod_opencast'),
-                    \core\output\notification::NOTIFY_ERROR
+                $notificationmessage,
+                \core\output\notification::NOTIFY_ERROR
             ));
         }
     }


### PR DESCRIPTION
* Fixes Opencast-Moodle/moodle-filter_opencast#54

* read paella json data properly from mod, (#57)

fixes #56

* Use Opencast PHP Library for api call

Change error message

* make sure lti launch gets a proper base url in both allinone and multi-nodes opencast instances

* change the service to search and make sure it is active

* get rid of services

---------