### PR TITLE
Migrate Settings from block_opencast to tool_opencast 

### DIFF
--- a/settings.php
+++ b/settings.php
@@ -57,7 +57,7 @@ if ($ADMIN->fulltree) {
                 get_string('setting_uselti_ocinstance_name', 'filter_opencast', $ocinstancename), ['target' => '_blank']);
             $description = get_string('setting_uselti_nolti_desc', 'filter_opencast', $link);
             $settings->add(
-                new admin_setting_configempty('block_opencast/uselti_' . $instance->id,
+                new admin_setting_configempty('tool_opencast/uselti_' . $instance->id,
                     get_string('setting_uselti', 'filter_opencast'),
                     $description));
         }

--- a/version.php
+++ b/version.php
@@ -26,11 +26,11 @@ defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'filter_opencast';
 $plugin->release = 'v4.5-r3';
-$plugin->version = 2025041500;
+$plugin->version = 2025042200;
 $plugin->requires = 2024100700; // Requires Moodle 4.5+.
 $plugin->supported = [405, 405];
 $plugin->maturity = MATURITY_STABLE;
 $plugin->dependencies = [
-    'tool_opencast' => 2024111100,
-    'mod_opencast' => 2024111100,
+    'tool_opencast' => 2025042200,
+    'mod_opencast' => 2025042200,
 ];

--- a/version.php
+++ b/version.php
@@ -26,7 +26,7 @@ defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'filter_opencast';
 $plugin->release = 'v4.5-r3';
-$plugin->version = 2024111102;
+$plugin->version = 2025041500;
 $plugin->requires = 2024100700; // Requires Moodle 4.5+.
 $plugin->supported = [405, 405];
 $plugin->maturity = MATURITY_STABLE;


### PR DESCRIPTION
This PR adapts mod_opencast to the migration of the settings from block_opencast to tool_opencast in order to make the block_opencast Plugin optional.
This PR is intended as a draft for the community to review and provide feedback on the proposed changes.

PR drafts are available in tool_opencast, block_opencast, filter_opencast, mod_opencast