### PR TITLE
Remove htmlspecialchars calls from hidden input fields

### DIFF
--- a/ltilaunch.php
+++ b/ltilaunch.php
@@ -63,7 +63,7 @@ if (confirm_sesskey()) {
     echo html_writer::start_tag('form', $formattributed);
 
     foreach ($ltiparams as $name => $value) {
-        $attributes = ['type' => 'hidden', 'name' => htmlspecialchars($name), 'value' => htmlspecialchars($value)];
+        $attributes = ['type' => 'hidden', 'name' => $name, 'value' => $value];
         echo html_writer::empty_tag('input', $attributes) . "\n";
     }
 


### PR DESCRIPTION
Hi,

consider removing the htmlspecialchars calls from hidden input fields, as html_writer::empty_tag already handles escaping attribute values, avoiding double escaping, which could otherwise lead to errors during signature verification.

